### PR TITLE
docs: readme has the correct git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ wez-logging saves the contents of the WezTerm scrollback buffer to a file.
 Clone this repository into your `$XDG_CONFIG_HOME/wezterm` directory:
 
 ```sh
-git clone https://github.com/sei40kr/wez-pain-control.git $XDG_CONFIG_HOME/wezterm
+git clone https://github.com/sei40kr/wez-logging.git $XDG_CONFIG_HOME/wezterm
 ```
 
 ## Usage


### PR DESCRIPTION
Hi, just noticed a minor thing in the readme.

---

I think this plugin is a cool idea! I got interested in making a feature for myself and I think this may be a good fit for a part of what I'm looking for.

My idea: I like to use neovim when I code and run tests in a separate wezterm window on another monitor. When there are errors, I would like to easily open the errors (files) in neovim somehow.